### PR TITLE
Fix label being cutoff in Newsletter registration

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -46,7 +46,8 @@
         }
 
         input {
-            padding-left: 35px;
+            padding: 0 0 0 35px; // Reset some default Safari padding values.
+            margin-right: 35px;
         }
 
         .title {
@@ -78,7 +79,8 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .block.newsletter {
-        width: 34%;
+        .lib-css(width, max-content);
+        max-width: 44%;
     }
 }
 


### PR DESCRIPTION
In this commit the label to Register in the newsletter that exists in the homepage had the text completely cut off on Tablet iOS devices

### Description
To solve this the width property was altered to use the max-content value, and a max-width property is also added. Also some paddings were set to 0 because Safari keeps adding some default padding values.

### Fixed Issues 
1. magento/magento2#21592: Newsletter subscription input box in footer: on iPad (9.7"), in portrait mode, placeholder text is not visible

### Manual testing scenarios
1. Go to the homepage of a clean Magento 2.3 installation on an iOS tablet device 9.7"
2. Check the Newsletter Subscription input field at the footer of the page
3. Make sure the input text is fully visible
4. Now visit the page on other browsers too and make sure that this still fixed

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
