### PR TITLE
Apply the same fix for Magento blank

### DIFF
--- a/app/design/frontend/Magento/blank/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/blank/Magento_Newsletter/web/css/source/_module.less
@@ -44,7 +44,8 @@
         }
 
         input {
-            padding-left: 35px;
+            margin-right: 35px;
+            padding: 0 0 0 35px; // Reset some default Safari padding values.
         }
 
         .title {
@@ -75,7 +76,8 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .block.newsletter {
-        width: 32%;
+        max-width: 44%;
+        width: max-content;
 
         .field {
             margin-right: 5px;

--- a/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
+++ b/app/design/frontend/Magento/luma/Magento_Newsletter/web/css/source/_module.less
@@ -79,8 +79,8 @@
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     .block.newsletter {
-        .lib-css(width, max-content);
         max-width: 44%;
+        width: max-content;
     }
 }
 


### PR DESCRIPTION
### Description
In this commit two changes are introduced. The first one is removing the .lib-css while applying the width style property and the other one is to apply the same changes for Magento Blank theme.

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. Remove lib-css from width property
2. Apply same fix for Blank theme

### Manual testing scenarios
1. Go to the homepage of blank theme ad then later on luma theme
2. Check te newsletter input field on both themes
3. It should look good on both themes on all devices

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
